### PR TITLE
Fix a bug that causes MouseOverImGuiWindow() to not work

### DIFF
--- a/src/preview.cpp
+++ b/src/preview.cpp
@@ -191,10 +191,8 @@ void InitImguiData(GuiDataContainer* guiData)
 // LOOK: Un-Comment to check ImGui Usage
 void RenderImGui()
 {
-	if(io->WantCaptureMouse)
-	{
-		mouseOverImGuiWinow = true;
-	}
+	mouseOverImGuiWinow = io->WantCaptureMouse;
+
 	ImGui_ImplOpenGL3_NewFrame();
 	ImGui_ImplGlfw_NewFrame();
 	ImGui::NewFrame();


### PR DESCRIPTION
Currently it's impossible to "unfocus" the GUI because a bool variable is not updated correctly.